### PR TITLE
mongodb comments id add

### DIFF
--- a/app.py
+++ b/app.py
@@ -105,9 +105,7 @@ def delete_comment(id):
 @app.route('/members/<id>')
 def render_teammember(id):
     _id = int(id)
-    print(_id)
     member = db.members.find_one({'member_id': _id})
-    print(member)
     return render_template('member.html', member=member)
 
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -175,6 +175,21 @@
                 });
         }
 
+        function delete_comment(id) {
+            fetch(`/members/${id}/comments/delete`, {
+                method: 'DELETE',
+                headers: {
+                    'Content-Type': 'application/json',
+                },
+                body: JSON.stringify({ memberid_give: id }),
+            })
+                .then((res) => res.json())
+                .then((data) => {
+                    alert(data['msg']);
+                    window.location.reload();
+                });
+        }
+
         function deletemember(id) {
             fetch('/members/memberid', {
                 method: 'DELETE',
@@ -185,6 +200,7 @@
             })
                 .then((res) => res.json())
                 .then((data) => {
+                    delete_comment(id)
                     alert(data['msg']);
                     window.location.reload();
                 });


### PR DESCRIPTION
코멘트 삭제하지 않고 멤버 삭제시, 몽고디비에 멤버아이디 기준 코멘트 남아있는 버그 확인후, index.html deletemember()함수 안에 deletecomment()추가하여 기존 코멘트들도 삭제되는 기능 추가 버전